### PR TITLE
fix: preserve pathname when persisting state to URL

### DIFF
--- a/src/utils/searchStringStorage.ts
+++ b/src/utils/searchStringStorage.ts
@@ -4,7 +4,7 @@ const updateHistory = (params: URLSearchParams) => {
   history.replaceState(
     null,
     "",
-    window.location.origin + "?" + params.toString(),
+    window.location.pathname + "?" + params.toString(),
   );
 };
 


### PR DESCRIPTION
## Problem

`updateHistory` in `src/utils/searchStringStorage.ts` rebuilt the URL from `window.location.origin`, which contains only the scheme + host and **no path**:

```ts
history.replaceState(null, "", window.location.origin + "?" + params.toString());
```

Every state write goes through this (changing a level, hue, scale, chroma, etc., all debounced through `setItem`). So as soon as the user edited anything on a non-root route — `/levels`, `/palette`, `/combinations`, `/export` — the address bar was silently rewritten to `/?...`, dropping the route.

Impact:
- Reloading after an edit kicks the user back to the Scales page.
- Copying the URL (or the "Sharable Link") from one of those routes loses the route.

## Fix

Use `window.location.pathname` so the current route is preserved while the query string is updated:

```ts
history.replaceState(null, "", window.location.pathname + "?" + params.toString());
```

## Testing

- `tsc --noEmit` clean
- `oxlint` 0 warnings / 0 errors
- `prettier --check` clean

Manual: edit a value on `/levels` → URL bar now stays `/levels?...` instead of collapsing to `/?...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)