### PR TITLE
refactor: swatch-centric computed color model

### DIFF
--- a/src/app/combinations/page.tsx
+++ b/src/app/combinations/page.tsx
@@ -1,17 +1,13 @@
 "use client";
 
-import {
-  allColors,
-  atomLevels,
-  ScaleDataWithComputedData,
-} from "@/atoms/userdata";
+import { allColors, ScaleDataWithComputedData, Swatch } from "@/atoms/userdata";
 import {
   Listbox,
   ListboxButton,
   ListboxOption,
   ListboxOptions,
 } from "@headlessui/react";
-import { type Oklch, wcagContrast, formatCss } from "culori";
+import { wcagContrast } from "culori";
 import clsx from "clsx";
 import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
@@ -21,32 +17,23 @@ import { ReactNode, useMemo } from "react";
 import { LuChevronDown } from "react-icons/lu";
 
 interface Combination {
-  bg: Oklch;
-  bgLevel: number;
-  fg: Oklch;
-  fgLevel: number;
+  bg: Swatch;
+  fg: Swatch;
   contrast: number;
 }
 
 const getCombosWithContrastRatioOrMore = (
-  levels: number[],
   bgScale: ScaleDataWithComputedData,
   fgScale: ScaleDataWithComputedData,
   minContrast: number,
   maxContrast = 21,
 ): Combination[] => {
   const result: Combination[] = [];
-  bgScale.colors.forEach((bg, bgIndex) => {
-    fgScale.colors.forEach((fg, fgIndex) => {
-      const contrast = wcagContrast(bg, fg);
+  bgScale.swatches.forEach((bg) => {
+    fgScale.swatches.forEach((fg) => {
+      const contrast = wcagContrast(bg.oklch, fg.oklch);
       if (contrast >= minContrast && contrast < maxContrast) {
-        result.push({
-          bg,
-          bgLevel: levels[bgIndex],
-          fg,
-          fgLevel: levels[fgIndex],
-          contrast,
-        });
+        result.push({ bg, fg, contrast });
       }
     });
   });
@@ -71,9 +58,9 @@ const Combinations = ({
         <span>{combinations.length} combos</span>
       </header>
       <ul className="flex flex-wrap gap-2">
-        {combinations.map(({ bg, bgLevel, fg, fgLevel, contrast }, index) => {
-          const hexBg = formatCss(bg);
-          const hexFg = formatCss(fg);
+        {combinations.map(({ bg, fg, contrast }, index) => {
+          const hexBg = bg.css;
+          const hexFg = fg.css;
           return (
             <li
               key={index}
@@ -81,9 +68,9 @@ const Combinations = ({
               style={{ backgroundColor: hexBg, color: hexFg }}
             >
               <div className="mb-1 text-lg font-bold">
-                <span>lv.{fgLevel}</span>
+                <span>lv.{fg.level}</span>
                 <hr style={{ borderColor: hexFg }} />
-                <span>lv.{bgLevel}</span>
+                <span>lv.{bg.level}</span>
               </div>
               <span className="text-xs">{round(contrast, 1)}</span>
             </li>
@@ -101,13 +88,13 @@ const ScaleDisplay = ({
   scale: ScaleDataWithComputedData;
   className?: string;
 }) => {
-  const { colors } = scale;
-  const index = Math.floor((colors.length - 1) / 2);
-  const color = colors[index];
+  const { swatches } = scale;
+  const index = Math.floor((swatches.length - 1) / 2);
+  const swatch = swatches[index];
   return (
     <div
       className={clsx("rounded-full", className)}
-      style={{ backgroundColor: formatCss(color) }}
+      style={{ backgroundColor: swatch.css }}
     />
   );
 };
@@ -166,7 +153,6 @@ const atomSelectedFGScaleName = atomWithStorage<string>(
 );
 
 export default function PageCombinations() {
-  const [levels] = useAtom(atomLevels);
   const [scales] = useAtom(allColors);
   const [bgScaleName, setBGScaleName] = useAtom(atomSelectedBGScaleName);
   const [fgScaleName, setFGScaleName] = useAtom(atomSelectedFGScaleName);
@@ -176,11 +162,11 @@ export default function PageCombinations() {
     const fgScale = scales.find((s) => s.name === fgScaleName);
     if (!bgScale || !fgScale) return {};
     return {
-      "7": getCombosWithContrastRatioOrMore(levels, bgScale, fgScale, 7),
-      "4.5": getCombosWithContrastRatioOrMore(levels, bgScale, fgScale, 4.5, 7),
-      "3": getCombosWithContrastRatioOrMore(levels, bgScale, fgScale, 3, 4.5),
+      "7": getCombosWithContrastRatioOrMore(bgScale, fgScale, 7),
+      "4.5": getCombosWithContrastRatioOrMore(bgScale, fgScale, 4.5, 7),
+      "3": getCombosWithContrastRatioOrMore(bgScale, fgScale, 3, 4.5),
     };
-  }, [scales, bgScaleName, fgScaleName, levels]);
+  }, [scales, bgScaleName, fgScaleName]);
   return (
     <section className="my-8 space-y-8">
       <h2 className="flex flex-wrap items-center gap-1 text-2xl font-medium">

--- a/src/app/combinations/page.tsx
+++ b/src/app/combinations/page.tsx
@@ -7,9 +7,8 @@ import {
   ListboxOption,
   ListboxOptions,
 } from "@headlessui/react";
-import { wcagContrast } from "culori";
 import clsx from "clsx";
-import { formatCss, type Oklch, wcagContrast } from "culori";
+import { wcagContrast } from "culori";
 import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { round } from "lodash";

--- a/src/atoms/userdata.ts
+++ b/src/atoms/userdata.ts
@@ -2,7 +2,13 @@ import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import * as jsoncrush from "jsoncrush";
 import { defaultScales } from "./defaultScales";
-import { clampChroma, formatCss, formatHex, type Oklch } from "culori";
+import {
+  clampChroma,
+  formatCss,
+  formatHex,
+  wcagLuminance,
+  type Oklch,
+} from "culori";
 import { bellShapeCurve } from "@/utils/bellShapeCurve";
 import { keyBy, mapValues, round, zipObject } from "lodash";
 import * as urlStorage from "@/utils/searchStringStorage";
@@ -52,54 +58,66 @@ export const atomUserData = atomWithStorage<ScaleData[]>("s", defaultScales, {
   removeItem: urlStorage.remove,
 });
 
-export interface ScaleDataWithComputedData extends ScaleData {
-  colors: Oklch[];
+export interface Swatch {
+  level: number;
+  oklch: Oklch;
+  hex: string;
+  css: string;
+  luminance: number;
 }
+
+export interface ScaleDataWithComputedData extends ScaleData {
+  swatches: Swatch[];
+}
+
+const computeSwatch = (
+  level: number,
+  index: number,
+  count: number,
+  hue: number,
+  chroma: ScaleData["chroma"],
+): Swatch => {
+  const { peak, steepness, multiplier } = chroma;
+  const l = (100 - level) / 100;
+  const c =
+    bellShapeCurve(peak, 0.001 * Math.pow(1000, steepness), index / count) *
+    multiplier;
+  const oklch = clampChroma({ mode: "oklch", l, c, h: hue }, "oklch", "p3");
+  oklch.c = round(c * 0.25 + oklch.c * 0.75, 5);
+  oklch.h = oklch.h ?? 0;
+  return {
+    level,
+    oklch,
+    hex: formatHex(oklch),
+    css: formatCss(oklch),
+    luminance: round(wcagLuminance(oklch), 2),
+  };
+};
 
 export const allColors = atom<ScaleDataWithComputedData[]>((get) => {
   const levels = get(atomLevels);
   const userData = get(atomUserData);
-  return userData.map(({ name, hue, chroma }) => {
-    const { peak, steepness, multiplier } = chroma;
-    return {
-      name,
-      hue,
-      chroma,
-      levels,
-      colors: levels.map((level, i) => {
-        const l = (100 - level) / 100;
-        const c =
-          bellShapeCurve(
-            peak,
-            0.001 * Math.pow(1000, steepness),
-            i / levels.length,
-          ) * multiplier;
-        const h = hue;
-        const color = clampChroma({ mode: "oklch", l, c, h }, "oklch", "p3");
-        color.c = c * 0.25 + color.c * 0.75;
-        color.c = round(color.c, 5);
-        return color;
-      }),
-    };
-  });
+  return userData.map(({ name, hue, chroma }) => ({
+    name,
+    hue,
+    chroma,
+    swatches: levels.map((level, index) =>
+      computeSwatch(level, index, levels.length, hue, chroma),
+    ),
+  }));
 });
 
 /* - - - - */
 
 export const atomSVGAllScales = atom<string>((get) => {
   const scales = get(allColors);
-  const levels = get(atomLevels);
   return `<svg>${scales
     .map((scale, i) => {
       const groupY = i * 120;
-      const rects = scale.colors.map((c, i) => {
-        const x = i * 100;
+      const rects = scale.swatches.map((swatch, j) => {
+        const x = j * 100;
         const y = 0;
-        return `\n    <rect id="level ${
-          levels[i]
-        }" width="100" height="100" x="${x}" y="${y}" fill="${formatHex(
-          c,
-        )}" />`;
+        return `\n    <rect id="level ${swatch.level}" width="100" height="100" x="${x}" y="${y}" fill="${swatch.hex}" />`;
       });
       return `\n  <g id="${scale.name}" y="${groupY}">${rects.join("")}\n  </g>`;
     })
@@ -108,12 +126,11 @@ export const atomSVGAllScales = atom<string>((get) => {
 
 export const atomTailwindConfig = atom<string>((get) => {
   const scales = get(allColors);
-  const levels = get(atomLevels);
   return JSON.stringify(
     mapValues(keyBy(scales, "name"), (scale) =>
       zipObject(
-        levels,
-        scale.colors.map((color) => formatHex(color)),
+        scale.swatches.map((swatch) => swatch.level),
+        scale.swatches.map((swatch) => swatch.hex),
       ),
     ),
     null,
@@ -123,17 +140,16 @@ export const atomTailwindConfig = atom<string>((get) => {
 
 export const atomJSONDesignTokens = atom<string>((get) => {
   const scales = get(allColors);
-  const levels = get(atomLevels);
   return JSON.stringify(
     mapValues(keyBy(scales, "name"), (scale) =>
       zipObject(
-        levels,
-        scale.colors.map((color) => ({
-          lightness: color.l,
-          chroma: color.c,
-          hue: color.h,
-          css: formatCss(color),
-          hex: formatHex(color),
+        scale.swatches.map((swatch) => swatch.level),
+        scale.swatches.map(({ oklch, css, hex }) => ({
+          lightness: oklch.l,
+          chroma: oklch.c,
+          hue: oklch.h,
+          css,
+          hex,
         })),
       ),
     ),
@@ -144,12 +160,10 @@ export const atomJSONDesignTokens = atom<string>((get) => {
 
 export const atomCSSVariables = atom<string>((get) => {
   const scales = get(allColors);
-  const levels = get(atomLevels);
   return scales
     .flatMap((scale) =>
-      scale.colors.map(
-        (color, index) =>
-          `--color-${scale.name}-${levels[index]}: ${formatCss(color)};`,
+      scale.swatches.map(
+        (swatch) => `--color-${scale.name}-${swatch.level}: ${swatch.css};`,
       ),
     )
     .join("\n");
@@ -157,19 +171,14 @@ export const atomCSSVariables = atom<string>((get) => {
 
 //
 
-export const exportScalesAsSVG = (
-  scales: ScaleDataWithComputedData[],
-  levels: number[],
-) => {
+export const exportScalesAsSVG = (scales: ScaleDataWithComputedData[]) => {
   return `<svg>${scales
     .map((scale, i) => {
       const groupY = i * 120;
-      const rects = scale.colors.map((c, i) => {
-        const x = i * 100;
+      const rects = scale.swatches.map((swatch, j) => {
+        const x = j * 100;
         const y = 0;
-        return `<rect id="level ${levels[i]}" width="100" height="100" x="${x}" y="${y}" fill="${formatHex(
-          c,
-        )}" />`;
+        return `<rect id="level ${swatch.level}" width="100" height="100" x="${x}" y="${y}" fill="${swatch.hex}" />`;
       });
       return `<g id="Scale with Hue ${scale.hue}" y="${groupY}">${rects.join("")}</g>`;
     })

--- a/src/components/MiniColorScales.tsx
+++ b/src/components/MiniColorScales.tsx
@@ -1,21 +1,20 @@
 "use client";
 
 import { allColors } from "@/atoms/userdata";
-import { formatCss } from "culori";
 import { useAtom } from "jotai/react";
 
 export const MiniColorScales = () => {
   const [scales] = useAtom(allColors);
   return (
     <dl className="grid grid-cols-12 items-center text-sm text-zinc-600">
-      {scales.map(({ name, colors }, index) => (
+      {scales.map(({ name, swatches }, index) => (
         <div className="contents" key={index}>
           <dt>{name}</dt>
           <dd className="col-span-11 flex">
-            {colors.map((color, index) => (
+            {swatches.map((swatch, index) => (
               <div
                 key={index}
-                style={{ backgroundColor: formatCss(color) }}
+                style={{ backgroundColor: swatch.css }}
                 className="h-8 w-full"
               />
             ))}

--- a/src/components/RowScale.tsx
+++ b/src/components/RowScale.tsx
@@ -7,7 +7,6 @@ import {
 import {
   ScaleDataWithComputedData,
   ScaleData,
-  atomLevels,
   exportScalesAsSVG,
 } from "@/atoms/userdata";
 import {
@@ -24,7 +23,7 @@ import { useAtom } from "jotai";
 import { round } from "lodash";
 import { LuCopy, LuShare, LuTrash } from "react-icons/lu";
 import { DtDd } from "./DtDd";
-import { formatCss, formatHex, Oklch, wcagLuminance } from "culori";
+import { formatCss, formatHex, Oklch } from "culori";
 import { Slider } from "./Slider";
 import { CurveVisualizer } from "./CurveVisualizer";
 import styles from "./RowScale.module.css";
@@ -46,8 +45,6 @@ export interface IRowScale {
 
 export function RowScale(props: IRowScale) {
   const { scale, updateScale, deleteScale } = props;
-  const { colors } = scale;
-  const [levels] = useAtom(atomLevels);
   const [dataPointVisibility] = useAtom(atomDataPointVisibility);
   return (
     <section className={clsx(styles.row, "my-6 grid gap-4 border-b pb-6")}>
@@ -82,7 +79,7 @@ export function RowScale(props: IRowScale) {
           <button
             className="btn"
             onClick={() => {
-              navigator.clipboard.writeText(exportScalesAsSVG([scale], levels));
+              navigator.clipboard.writeText(exportScalesAsSVG([scale]));
             }}
           >
             <LuShare /> Copy SVG
@@ -115,14 +112,11 @@ export function RowScale(props: IRowScale) {
           (styles.levels, "-mb-3 flex max-w-full gap-px overflow-auto pb-3")
         }
       >
-        {levels.map((level, i) => {
-          const color = colors[i];
-          const hex = formatHex(color);
-          const cssOKLCH = formatCss(color);
-          const relativeLuminance = round(wcagLuminance(color), 2);
+        {scale.swatches.map((swatch) => {
+          const { level, oklch, hex, css: cssOKLCH, luminance } = swatch;
           const onSurface: Oklch = {
             mode: "oklch",
-            l: color.l > 0.5 ? 0 : 1,
+            l: oklch.l > 0.5 ? 0 : 1,
             c: 0,
           };
           return (
@@ -163,13 +157,13 @@ export function RowScale(props: IRowScale) {
                     EnumViewDataPoint.ScaleLevel,
                   ) && <DtDd term="lv." desc={level} />}
                   {dataPointVisibility.includes(EnumViewDataPoint.LCH_L) && (
-                    <DtDd term="L" desc={round(color.l, 2)} />
+                    <DtDd term="L" desc={round(oklch.l, 2)} />
                   )}
                   {dataPointVisibility.includes(EnumViewDataPoint.LCH_C) && (
-                    <DtDd term="C" desc={round(color.c, 2)} />
+                    <DtDd term="C" desc={round(oklch.c, 2)} />
                   )}
                   {dataPointVisibility.includes(EnumViewDataPoint.LCH_H) && (
-                    <DtDd term="H" desc={color.h} />
+                    <DtDd term="H" desc={oklch.h} />
                   )}
                   {dataPointVisibility.includes(EnumViewDataPoint.Hex) && (
                     <DtDd
@@ -187,7 +181,7 @@ export function RowScale(props: IRowScale) {
                           L<sup>rel</sup>
                         </>
                       }
-                      desc={relativeLuminance}
+                      desc={luminance}
                     />
                   )}
                 </dl>

--- a/src/components/RowScale.tsx
+++ b/src/components/RowScale.tsx
@@ -5,8 +5,6 @@ import {
   EnumViewDataPoint,
 } from "@/atoms/applicationState";
 import {
-  ScaleDataWithComputedData,
-  ScaleData,
   exportScalesAsSVG,
   ScaleData,
   ScaleDataWithComputedData,
@@ -21,11 +19,10 @@ import {
   PopoverPanel,
 } from "@headlessui/react";
 import clsx from "clsx";
-import { formatCss, formatHex, Oklch, wcagLuminance } from "culori";
+import { formatCss, formatHex, Oklch } from "culori";
 import { useAtom } from "jotai";
 import { round } from "lodash";
 import * as icons from "lucide-react";
-import { formatCss, formatHex, Oklch } from "culori";
 import { CurveVisualizer } from "./CurveVisualizer";
 import { DtDd } from "./DtDd";
 import styles from "./RowScale.module.css";


### PR DESCRIPTION
Implements the data-model plan: makes computed color data self-describing so consumers stop re-joining the two parallel arrays (`colors[i]` ↔ `levels[i]`) by array index.

## What changed

Before, `allColors` produced `colors: Oklch[]` and the level for each color lived in a *separate* `atomLevels` array. Every consumer had to index back into `levels` by position, so `atomLevels` leaked into the components and the four serializers each re-`zipObject(levels, colors)`. The computed atom also emitted a `levels` property that wasn't in `ScaleDataWithComputedData` (silently dropped — a type lie).

Now a swatch carries everything it needs:

```ts
interface Swatch {
  level: number;
  oklch: Oklch;
  hex: string;
  css: string;
  luminance: number;
}
interface ScaleDataWithComputedData extends ScaleData {
  swatches: Swatch[];
}
```

- **Normalize:** `oklch.h` is set to `?? 0` at construction, so downstream never handles `undefined` hue.
- **No alias:** `colors` is removed outright (clean cut, ~4 consumers) rather than kept alongside `swatches`.
- **Centralize precision:** chroma rounding and `wcagLuminance` now live in a single `computeSwatch` helper instead of being recomputed ad hoc in `RowScale`/`combinations`.

### Consumers

- `userdata.ts` — `computeSwatch` helper; `atomSVGAllScales`, `atomTailwindConfig`, `atomJSONDesignTokens`, `atomCSSVariables`, `exportScalesAsSVG` read `scale.swatches`. `exportScalesAsSVG` drops its now-unused `levels` arg.
- `RowScale.tsx` / `MiniColorScales.tsx` / `combinations/page.tsx` — iterate `swatches`; `atomLevels` no longer threaded through, and the local hex/css/luminance recompute is gone.

## Scope / compatibility

Source of truth (`ScaleData[]` + levels in the URL) is unchanged — this only touches the derived layer. **Export payloads (SVG / CSS / Tailwind / JSON) are byte-for-byte unchanged.**

## Testing

- `tsc --noEmit` clean
- `oxlint` 0 warnings / 0 errors
- `prettier --check` clean
- `next build` succeeds (all 12 routes prerender)

## Follow-ups (out of scope, flagged in the investigation)

- Decode validation/versioning in `objDecoder`/`arrDecoder` (crash hardening)
- Stable scale identity (`id` vs array index / non-unique `name`)
- String-valued `EnumViewDataPoint` (persisted-prefs corruption on reorder)
- URL-vs-localStorage persistence reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)