### PR TITLE
refactor: validate URL params with purify-ts Codec

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next": "14.2.5",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.8",
+    "purify-ts": "^2.1.4",
     "react": "^18",
     "react-dom": "^18",
     "react-use": "^17.5.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.6.8
         version: 0.6.8(prettier@3.3.3)
+      purify-ts:
+        specifier: ^2.1.4
+        version: 2.1.4
       react:
         specifier: ^18
         version: 18.3.1
@@ -363,6 +366,9 @@ packages:
 
   '@types/js-cookie@2.2.7':
     resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -1550,6 +1556,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  purify-ts@2.1.4:
+    resolution: {integrity: sha512-PKSMYPJRoxxHdsI9I2/caXmMDoAFd15lHmOAJsq55cl9o2gHH6NWaPTuwRW6cNkTRhZRkmoTN7U6062mRMcIsA==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2172,6 +2181,8 @@ snapshots:
   '@types/culori@2.1.1': {}
 
   '@types/js-cookie@2.2.7': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
 
@@ -3505,6 +3516,10 @@ snapshots:
       react-is: 16.13.1
 
   punycode@2.3.1: {}
+
+  purify-ts@2.1.4:
+    dependencies:
+      '@types/json-schema': 7.0.15
 
   queue-microtask@1.2.3: {}
 

--- a/src/atoms/userdata.ts
+++ b/src/atoms/userdata.ts
@@ -1,7 +1,5 @@
-import { atom } from "jotai";
-import { atomWithStorage } from "jotai/utils";
-import * as jsoncrush from "jsoncrush";
-import { defaultScales } from "./defaultScales";
+import { bellShapeCurve } from "@/utils/bellShapeCurve";
+import * as urlStorage from "@/utils/searchStringStorage";
 import {
   clampChroma,
   formatCss,
@@ -9,9 +7,12 @@ import {
   wcagLuminance,
   type Oklch,
 } from "culori";
-import { bellShapeCurve } from "@/utils/bellShapeCurve";
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import * as jsoncrush from "jsoncrush";
 import { keyBy, mapValues, round, zipObject } from "lodash";
-import * as urlStorage from "@/utils/searchStringStorage";
+import * as Purify from "purify-ts";
+import { defaultScales } from "./defaultScales";
 
 export interface ScaleData {
   name: string;
@@ -25,18 +26,44 @@ export interface ScaleData {
 
 export const defaultLevels = [2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95];
 
+const finiteNumber = Purify.Codec.custom<number>({
+  decode: (input) =>
+    typeof input === "number" && Number.isFinite(input)
+      ? Purify.Either.of(input)
+      : Purify.Left(`Expected a finite number, got ${String(input)}`),
+  encode: (input) => input,
+});
+
+const chromaCodec = Purify.Codec.interface({
+  multiplier: Purify.number,
+  peak: Purify.number,
+  steepness: Purify.number,
+});
+
+const scaleDataCodec = Purify.Codec.interface({
+  name: Purify.string,
+  hue: Purify.number,
+  chroma: chromaCodec,
+});
+
 const arrEncoder = (x: number[]) => x.join("_");
-const arrDecoder = (x: string) => x.split("_").map((x) => parseInt(x));
+const arrDecode = (raw: string): Purify.Either<string, number[]> =>
+  Purify.array(finiteNumber).decode(raw.split("_").map((x) => parseInt(x)));
+
 const objEncoder = (x: object) =>
   encodeURIComponent(jsoncrush.default.crush(JSON.stringify(x)));
-const objDecoder = (x: string) =>
-  JSON.parse(jsoncrush.default.uncrush(decodeURIComponent(x)));
+const objDecode = (raw: string): Purify.Either<string, ScaleData[]> =>
+  Purify.Either.encase(() =>
+    JSON.parse(jsoncrush.default.uncrush(decodeURIComponent(raw))),
+  )
+    .mapLeft((err) => (err as Error).message)
+    .chain((parsed) => Purify.array(scaleDataCodec).decode(parsed));
 
 export const atomLevels = atomWithStorage("l", defaultLevels, {
   getItem(key, initialValue) {
     return urlStorage.getItem<number[]>(key, initialValue, {
       encode: arrEncoder,
-      decode: arrDecoder,
+      decode: arrDecode,
     });
   },
   setItem(key, value) {
@@ -49,7 +76,7 @@ export const atomUserData = atomWithStorage<ScaleData[]>("s", defaultScales, {
   getItem(key, initialValue) {
     return urlStorage.getItem<ScaleData[]>(key, initialValue, {
       encode: objEncoder,
-      decode: objDecoder,
+      decode: objDecode,
     });
   },
   setItem(key, value) {

--- a/src/atoms/userdata.ts
+++ b/src/atoms/userdata.ts
@@ -1,17 +1,11 @@
 import { bellShapeCurve } from "@/utils/bellShapeCurve";
 import * as urlStorage from "@/utils/searchStringStorage";
-import {
-  clampChroma,
-  formatCss,
-  formatHex,
-  wcagLuminance,
-  type Oklch,
-} from "culori";
+import * as culori from "culori";
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import * as jsoncrush from "jsoncrush";
-import { keyBy, mapValues, round, zipObject } from "lodash";
-import * as Purify from "purify-ts";
+import _ from "lodash";
+import * as purify from "purify-ts";
 import { defaultScales } from "./defaultScales";
 
 export interface ScaleData {
@@ -26,38 +20,38 @@ export interface ScaleData {
 
 export const defaultLevels = [2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95];
 
-const finiteNumber = Purify.Codec.custom<number>({
+const finiteNumber = purify.Codec.custom<number>({
   decode: (input) =>
     typeof input === "number" && Number.isFinite(input)
-      ? Purify.Either.of(input)
-      : Purify.Left(`Expected a finite number, got ${String(input)}`),
+      ? purify.Either.of(input)
+      : purify.Left(`Expected a finite number, got ${String(input)}`),
   encode: (input) => input,
 });
 
-const chromaCodec = Purify.Codec.interface({
-  multiplier: Purify.number,
-  peak: Purify.number,
-  steepness: Purify.number,
+const chromaCodec = purify.Codec.interface({
+  multiplier: purify.number,
+  peak: purify.number,
+  steepness: purify.number,
 });
 
-const scaleDataCodec = Purify.Codec.interface({
-  name: Purify.string,
-  hue: Purify.number,
+const scaleDataCodec = purify.Codec.interface({
+  name: purify.string,
+  hue: purify.number,
   chroma: chromaCodec,
 });
 
 const arrEncoder = (x: number[]) => x.join("_");
-const arrDecode = (raw: string): Purify.Either<string, number[]> =>
-  Purify.array(finiteNumber).decode(raw.split("_").map((x) => parseInt(x)));
+const arrDecode = (raw: string): purify.Either<string, number[]> =>
+  purify.array(finiteNumber).decode(raw.split("_").map((x) => parseInt(x)));
 
 const objEncoder = (x: object) =>
   encodeURIComponent(jsoncrush.default.crush(JSON.stringify(x)));
-const objDecode = (raw: string): Purify.Either<string, ScaleData[]> =>
-  Purify.Either.encase(() =>
+const objDecode = (raw: string): purify.Either<string, ScaleData[]> =>
+  purify.Either.encase(() =>
     JSON.parse(jsoncrush.default.uncrush(decodeURIComponent(raw))),
   )
     .mapLeft((err) => (err as Error).message)
-    .chain((parsed) => Purify.array(scaleDataCodec).decode(parsed));
+    .chain((parsed) => purify.array(scaleDataCodec).decode(parsed));
 
 export const atomLevels = atomWithStorage("l", defaultLevels, {
   getItem(key, initialValue) {
@@ -87,7 +81,7 @@ export const atomUserData = atomWithStorage<ScaleData[]>("s", defaultScales, {
 
 export interface Swatch {
   level: number;
-  oklch: Oklch;
+  oklch: culori.Oklch;
   hex: string;
   css: string;
   luminance: number;
@@ -109,15 +103,19 @@ const computeSwatch = (
   const c =
     bellShapeCurve(peak, 0.001 * Math.pow(1000, steepness), index / count) *
     multiplier;
-  const oklch = clampChroma({ mode: "oklch", l, c, h: hue }, "oklch", "p3");
-  oklch.c = round(c * 0.25 + oklch.c * 0.75, 5);
+  const oklch = culori.clampChroma(
+    { mode: "oklch", l, c, h: hue },
+    "oklch",
+    "p3",
+  );
+  oklch.c = _.round(c * 0.25 + oklch.c * 0.75, 5);
   oklch.h = oklch.h ?? 0;
   return {
     level,
     oklch,
-    hex: formatHex(oklch),
-    css: formatCss(oklch),
-    luminance: round(wcagLuminance(oklch), 2),
+    hex: culori.formatHex(oklch),
+    css: culori.formatCss(oklch),
+    luminance: _.round(culori.wcagLuminance(oklch), 2),
   };
 };
 
@@ -154,8 +152,8 @@ export const atomSVGAllScales = atom<string>((get) => {
 export const atomTailwindConfig = atom<string>((get) => {
   const scales = get(allColors);
   return JSON.stringify(
-    mapValues(keyBy(scales, "name"), (scale) =>
-      zipObject(
+    _.mapValues(_.keyBy(scales, "name"), (scale) =>
+      _.zipObject(
         scale.swatches.map((swatch) => swatch.level),
         scale.swatches.map((swatch) => swatch.hex),
       ),
@@ -168,8 +166,8 @@ export const atomTailwindConfig = atom<string>((get) => {
 export const atomJSONDesignTokens = atom<string>((get) => {
   const scales = get(allColors);
   return JSON.stringify(
-    mapValues(keyBy(scales, "name"), (scale) =>
-      zipObject(
+    _.mapValues(_.keyBy(scales, "name"), (scale) =>
+      _.zipObject(
         scale.swatches.map((swatch) => swatch.level),
         scale.swatches.map(({ oklch, css, hex }) => ({
           lightness: oklch.l,

--- a/src/utils/searchStringStorage.ts
+++ b/src/utils/searchStringStorage.ts
@@ -1,5 +1,5 @@
-import { debounce } from "lodash";
-import * as Purify from "purify-ts";
+import _ from "lodash";
+import * as purify from "purify-ts";
 
 const updateHistory = (params: URLSearchParams) => {
   history.replaceState(
@@ -9,7 +9,7 @@ const updateHistory = (params: URLSearchParams) => {
   );
 };
 
-export const setItem = debounce((key: string, value: string) => {
+export const setItem = _.debounce((key: string, value: string) => {
   const params = new URLSearchParams(window.location.search);
   params.set(key, value);
   updateHistory(params);
@@ -23,7 +23,7 @@ export const getItem = <T = unknown>(
     decode,
   }: {
     encode: (x: T) => string;
-    decode: (x: string) => Purify.Either<string, T>;
+    decode: (x: string) => purify.Either<string, T>;
   },
 ): T => {
   const existingParams = new URLSearchParams(window.location.search);

--- a/src/utils/searchStringStorage.ts
+++ b/src/utils/searchStringStorage.ts
@@ -1,4 +1,5 @@
 import { debounce } from "lodash";
+import * as Purify from "purify-ts";
 
 const updateHistory = (params: URLSearchParams) => {
   history.replaceState(
@@ -17,15 +18,21 @@ export const setItem = debounce((key: string, value: string) => {
 export const getItem = <T = unknown>(
   key: string,
   initialValue: T,
-  { encode, decode }: { encode: (x: T) => string; decode: (x: string) => T },
-) => {
+  {
+    encode,
+    decode,
+  }: {
+    encode: (x: T) => string;
+    decode: (x: string) => Purify.Either<string, T>;
+  },
+): T => {
   const existingParams = new URLSearchParams(window.location.search);
   const existingData = existingParams.get(key);
   if (!existingData) {
     setItem(key, encode(initialValue));
     return initialValue;
   }
-  return decode(existingData);
+  return decode(existingData).orDefault(initialValue);
 };
 
 export const remove = (key: string) => {


### PR DESCRIPTION
## Summary

- Adds purify-ts `Codec`-based runtime validation to both URL parameter decoders, addressing sharp edge #2 from CLAUDE.md
- `objDecode` wraps `JSON.parse`/`jsoncrush.uncrush` in `Either.encase` to catch throws, then validates the parsed value's shape against a `ScaleData` codec — malformed URLs no longer crash the app at atom init
- `arrDecode` validates `parseInt` results with a custom `finiteNumber` codec that rejects `NaN`/`Infinity` (the built-in `purify.number` accepts both)
- `searchStringStorage.getItem` now takes `decode: (x: string) => Either<string, T>` and calls `.orDefault(initialValue)`, so any decode failure silently falls back to defaults

## Test plan

- [x] `pnpm build` passes with no type errors
- [x] `pnpm check` passes
- [x] Navigate to `?l=abc_xyz` — app loads with default levels, no crash
- [x] Navigate to `?s=INVALIDBASE64` — app loads with default scales, no crash
- [x] Fresh load with no query params — URL gets populated with defaults, normal behavior
- [x] Modify a scale, copy URL, reload — all state round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)